### PR TITLE
Add metrics output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ _cgo_export.*
 
 _testmain.go
 
+concept-ingester
+
 *.exe
 *.test
 *.prof

--- a/README.md
+++ b/README.md
@@ -2,12 +2,19 @@
 
 __An API for reading concepts off of the kafka queue and sending them to the appropriate writer__
 
-## Installation & running locally
+## Installation
 
 * `go get github.com/Financial-Times/concept-ingester`
 * `cd $GOPATH/src/github.com/Financial-Times/concept-ingester`
 * `go install`
+
+## Running in a cluster
 * `$GOPATH/bin/concept-ingester --services-list="people-rw-neo4j-blue,organisations-rw-neo4j-blue" --port="8081" --vulcan_addr="http://localhost:8080" --consumer_group_id="TestConcepts" --consumer_autocommit_enable=true --topic="Concept" --consumer_offset="smallest" --consumer_queue_id="kafka" --throttle=10`
+
+Some comments about configuration parameters:  
+* --vulcan_addr     the vulcan address, host and port
+* --services-list   comma separated list of neo4j writers - do not append a port for running in the cluster
+* --topic, --consumer_group_id, --consumer_autocommit_enable, --consumer_offset, --consumer_queue_id see the message-queue-gonsumer library  
 
 ## Healthchecks
 * Check connectivity [http://localhost:8080/__health](http://localhost:8080/__health)
@@ -15,12 +22,6 @@ __An API for reading concepts off of the kafka queue and sending them to the app
 
 ##Examples:
 ### How to run locally not in the cluster
-`concept-ingester --services-list="alphaville-series-rw-neo4j:8092" --port="8089" --vulcan_addr="http://localhost:8082" --consumer_group_id="alphaville-series" --topic="Concept" --consumer_of fset="smallest" --consumer_queue_id="kafka" 
+`concept-ingester --services-list="alphaville-series-rw-neo4j:8092" --port="8089" --vulcan_addr="http://localhost:8082" --consumer_group_id="alphaville-series" --topic="Concept" --consumer_of fset="smallest" --consumer_queue_id="kafka"
 `  
-This run configuration overrides host:port for kafka-rest-proxy (--vulcan_addr) and supplies the port for the xxx-rw-neo4j service that is assumed to be running on localhost.
-If the app is to run in the cluster there is no need to append port to the writer service.  
-
-Some comments about configuration parameters:  
-* --vulcan_addr     takes a list of hosts and if not in the cluster is an address of the kafka-rest-proxy (in the cluster it is resolved to vulkan address)  
-* --services-list   comma separated list of neo4j writers - one per concept  
-* --port                port of this app   
+To run locally against local writers, specify the port each of these writers are running on (the writer address will be resolved to localhost:[specified-port]). Override the vulcan-addr parameter to point to the host:port of a kafka-rest-proxy.

--- a/handlers.go
+++ b/handlers.go
@@ -13,9 +13,9 @@ import (
 )
 
 type httpHandlers struct {
-	baseURLSlice []string
-	vulcanAddr   string
-	topic        string
+	baseURLMappings map[string]string
+	vulcanAddr      string
+	topic           string
 }
 
 func (hh *httpHandlers) kafkaProxyHealthCheck() v1a.Check {
@@ -53,7 +53,7 @@ func (hh *httpHandlers) checkCanConnectToKafkaProxy() (string, error) {
 }
 
 func (hh *httpHandlers) checkCanConnectToWriters() (string, error) {
-	err := checkWriterAvailability(hh.baseURLSlice)
+	err := checkWriterAvailability(hh.baseURLMappings)
 	if err != nil {
 		return fmt.Sprintf("Healthcheck: Writer not available: %v", err.Error()), err
 	}
@@ -119,8 +119,8 @@ func (hh *httpHandlers) goodToGo(writer http.ResponseWriter, req *http.Request) 
 	}
 }
 
-func checkWriterAvailability(baseURLSlice []string) error {
-	for _, baseURL := range baseURLSlice {
+func checkWriterAvailability(baseURLMapping map[string]string) error {
+	for _, baseURL := range baseURLMapping {
 		resp, err := http.Get(baseURL + "/__gtg")
 		if err != nil {
 			return fmt.Errorf("Error calling writer at %s : %v", baseURL+"/__gtg", err)

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	queueConsumer "github.com/Financial-Times/message-queue-gonsumer/consumer"
+	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/assert"
 
 	"strings"
@@ -23,7 +24,7 @@ var uuid = "5e0ad5e5-c3d4-387d-9875-ec15501808e5"
 var validMessageTypeOrganisations = "organisations"
 var invalidMessageType = "animals"
 
-func TestMessageProcessingHappyPath(t *testing.T) {
+func TestMessageProcessingHappyPathIncrementsSuccessMeter(t *testing.T) {
 	// Test server that always responds with 200 code
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
@@ -35,6 +36,8 @@ func TestMessageProcessingHappyPath(t *testing.T) {
 		"organisations-rw-neo4j-blue": server.URL,
 	}
 
+	successMeterInitialCount, failureMeterInitialCount := getCounts()
+
 	ing := ingesterService{baseURLMappings: mockedWriterMappings, client: http.Client{}}
 
 	err := ing.processMessage(createMessage(uuid, validMessageTypeOrganisations))
@@ -42,9 +45,13 @@ func TestMessageProcessingHappyPath(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(err, "Should complete without error")
 
+	successMeterFinalCount, failureMeterFinalCount := getCounts()
+
+	assert.True(successMeterFinalCount-successMeterInitialCount == 1, "Should have incremented SuccessCount by 1")
+	assert.True(failureMeterFinalCount-failureMeterInitialCount == 0, "Should not have incremented FailureCount")
 }
 
-func TestMessageProcessingUnhappyPath(t *testing.T) {
+func TestMessageProcessingUnhappyPathIncrementsFailureMeter(t *testing.T) {
 	// Test server that always responds with 500 code
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
@@ -56,12 +63,25 @@ func TestMessageProcessingUnhappyPath(t *testing.T) {
 		"organisations-rw-neo4j-blue": server.URL,
 	}
 
+	successMeterInitialCount, failureMeterInitialCount := getCounts()
+
 	ing := ingesterService{baseURLMappings: mockedWriterMappings, client: http.Client{}}
 
 	err := ing.processMessage(createMessage(uuid, validMessageTypeOrganisations))
 
 	assert := assert.New(t)
 	assert.Error(err, "Should error")
+
+	successMeterFinalCount, failureMeterFinalCount := getCounts()
+
+	assert.True(successMeterFinalCount-successMeterInitialCount == 0, "Should not have incremented SuccessCount")
+	assert.True(failureMeterFinalCount-failureMeterInitialCount == 1, "Should have incremented FailureCount by 1")
+}
+
+func getCounts() (int64, int64) {
+	successMeter := metrics.GetOrRegisterMeter("organisations_SUCCESS", metrics.DefaultRegistry)
+	failureMeter := metrics.GetOrRegisterMeter("organisations_FAILURE", metrics.DefaultRegistry)
+	return successMeter.Count(), failureMeter.Count()
 }
 
 func TestWriterServiceSliceCreationCluster(t *testing.T) {
@@ -82,34 +102,34 @@ func TestWriterServiceSliceCreationLocal(t *testing.T) {
 
 func TestUuidAndMessageTypeAreExtractedFromMessage(t *testing.T) {
 	validMessage := createMessage(uuid, validMessageTypeOrganisations)
-	ingestionType, uuid := extractMessageTypeAndId(validMessage.Headers)
+	extractedIngestionType, extractedUUID := extractMessageTypeAndId(validMessage.Headers)
 	assert := assert.New(t)
-	assert.Equal("organisations", ingestionType)
-	assert.Equal("5e0ad5e5-c3d4-387d-9875-ec15501808e5", uuid)
+	assert.Equal("organisations", extractedIngestionType)
+	assert.Equal("5e0ad5e5-c3d4-387d-9875-ec15501808e5", extractedUUID)
 }
 
 func TestWriterUrlIsResolvedCorrectlyAndRequestIsNotNull(t *testing.T) {
 	validMessage := createMessage(uuid, validMessageTypeOrganisations)
-	request, reqUrl, err := resolveWriterAndCreateRequest(validMessageTypeOrganisations, strings.NewReader(validMessage.Body), uuid, correctWriterMappings)
+	request, reqURL, err := resolveWriterAndCreateRequest(validMessageTypeOrganisations, strings.NewReader(validMessage.Body), uuid, correctWriterMappings)
 	assert := assert.New(t)
 	assert.NoError(err)
-	assert.Equal("http://localhost:8080/__organisations-rw-neo4j-blue/organisations/5e0ad5e5-c3d4-387d-9875-ec15501808e5", reqUrl)
+	assert.Equal("http://localhost:8080/__organisations-rw-neo4j-blue/organisations/5e0ad5e5-c3d4-387d-9875-ec15501808e5", reqURL)
 	assert.NotNil(request, "Request is nil")
 }
 
 func TestErrorIsThrownWhenIngestionTypeMatchesNoWriters(t *testing.T) {
 	validMessage := createMessage(uuid, invalidMessageType)
-	_, reqUrl, err := resolveWriterAndCreateRequest(invalidMessageType, strings.NewReader(validMessage.Body), uuid, correctWriterMappings)
+	_, reqURL, err := resolveWriterAndCreateRequest(invalidMessageType, strings.NewReader(validMessage.Body), uuid, correctWriterMappings)
 	assert := assert.New(t)
-	assert.Equal("", reqUrl)
+	assert.Equal("", reqURL)
 	assert.Error(err, "No configured writer for concept: "+invalidMessageType)
 }
 
-func createMessage(messageId string, messageType string) queueConsumer.Message {
+func createMessage(messageID string, messageType string) queueConsumer.Message {
 	return queueConsumer.Message{
 		Headers: map[string]string{
 			"Content-Type":      "application/json",
-			"Message-Id":        messageId,
+			"Message-Id":        messageID,
 			"Message-Timestamp": "2016-06-16T08:14:36.910Z",
 			"Message-Type":      messageType,
 			"Origin-System-Id":  "http://cmdb.ft.com/systems/upp",

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,8 @@ var uuid = "5e0ad5e5-c3d4-387d-9875-ec15501808e5"
 var validMessageType = "organisations"
 var invalidMessageType = "animals"
 
+//func Test
+
 func TestWriterServiceSliceCreationCluster(t *testing.T) {
 	writerMappings := createWriterMappings(peopleService+","+organisationsService, "http://localhost:8080")
 	assert := assert.New(t)


### PR DESCRIPTION
Set up a meter for each concept type and for success vs failure, and output those values to graphite.

Also, change the setup for cluster vs local running of the concept ingester, so that we won't need to make any changes to any writer endpoints - the concept ingester will know that the people rw is at localhost:8070, for example.