### PR TITLE
Added additional logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -293,6 +293,9 @@ func sendToWriter(ingestionType string, msgBody string, uuid string, elasticWrit
 		log.Errorf("Cannot create write request: [%v]", err)
 	}
 	request.ContentLength = -1
+
+	log.Infof("Sending %s with uuid: %s to %s", ingestionType, uuid, elasticWriter)
+
 	resp, reqErr := httpClient.Do(request)
 	if reqErr != nil {
 		return fmt.Errorf("reqURL=[%s] concept=[%s] uuid=[%s] error=[%v]", reqURL, ingestionType, uuid, reqErr)


### PR DESCRIPTION
One simple line logs what the concept is and where we are sending it. Now we have fixed our journald issues this shouldn't be an issue, after all we are logging all the health checks 

`level=info msg="Sending sections with uuid: d24f498c-add6-3499-9696-a8412408373c to http://xxx:8080/__sections-rw-neo4j"`