### PR TITLE
Make concept-ingester dual-stack + helm integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ _cgo_export.*
 
 _testmain.go
 
-concept-ingester
+/concept-ingester
 
 *.exe
 *.test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,3 @@
+@Library('k8s-pipeline-lib') _
+
+uppEntryPointForJenkinsfile()

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Some comments about configuration parameters:
 * --services-list   comma separated list of neo4j writers - do not append a port for running in the cluster
 * --elastic-service elasticsearch writer name
 * --topic, --consumer_group_id, --consumer_autocommit_enable, --consumer_offset, --consumer_queue_id see the message-queue-gonsumer library  
-
+* the `--consumer_queue_id/QUEUE_ID` is used as a switch between clusters with vulcan-routing and those without - if this param is set, we assume vulcan-based routing.
 ## Healthchecks
 * Check connectivity [http://localhost:8080/__health](http://localhost:8080/__health)
 * Good to Go: [http://localhost:8080/__gtg](http://localhost:8080/__gtg)

--- a/helm/concept-ingester/.helmignore
+++ b/helm/concept-ingester/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/concept-ingester/Chart.yaml
+++ b/helm/concept-ingester/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: concept-ingester Helm chart for Kubernetes
+name: concept-ingester
+version: 0.0.0  # this entry can be left untouched as it is automatically handled by Jenkins pipeline

--- a/helm/concept-ingester/app-configs/concept-ingester_delivery.yaml
+++ b/helm/concept-ingester/app-configs/concept-ingester_delivery.yaml
@@ -1,0 +1,7 @@
+# Values used for the deployed application.
+replicaCount: 2
+service:
+  name: concept-ingester
+env:
+  graphite:
+    prefix: "coco.services.k8s.concept-ingester"

--- a/helm/concept-ingester/templates/_helpers.tpl
+++ b/helm/concept-ingester/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/concept-ingester/templates/deployment.yaml
+++ b/helm/concept-ingester/templates/deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   name: {{ .Values.service.name }} 
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}" 
+    chart: "{{ .Chart.Name | trunc 63 }}"
+    chartVersion: "{{ .Chart.Version | trunc 63 }}" 
     visualize: "true" 
     app: {{ .Values.service.name }} 
 spec:

--- a/helm/concept-ingester/templates/deployment.yaml
+++ b/helm/concept-ingester/templates/deployment.yaml
@@ -1,0 +1,71 @@
+##this is an example deployment.yaml that should be customized in order to meet the configuration for app k8s deployment
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Values.service.name }} 
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}" 
+    visualize: "true" 
+    app: {{ .Values.service.name }} 
+spec:
+  replicas: {{ .Values.replicaCount }} 
+  selector: 
+    matchLabels:
+      app: {{ .Values.service.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.service.name }}
+        visualize: "true" 
+    spec:
+      containers: 
+      - name: {{ .Values.service.name }} 
+        image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env: 
+        - name: PORT
+          value: "8080"
+        - name: VULCAN_ADDR
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
+        - name: GROUP_ID
+          value: "RedConcepts"
+        - name: TOPIC
+          value: "Concept"
+        - name: SERVICES
+          value: "http://content-rw-neo4j:8080,http://people-rw-neo4j:8080,http://organisations-rw-neo4j:8080,http://memberships-rw-neo4j:8080,http://brands-rw-neo4j:8080,http://roles-rw-neo4j:8080,http://financial-instruments-rw-neo4j:8080,http://industry-classifications-rw-neo4j:8080"
+        - name: ELASTICSEARCH_WRITER_ADDRESS
+          value: "http://concept-rw-elasticsearch:8080"
+        - name: GRAPHITE_TCP_AUTHORITY
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
+        - name: GRAPHITE_PREFIX
+          value: "coco.services.k8s.concept-ingester"
+        - name: OFFSET
+          value: "largest"
+        - name: COMMIT_ENABLE
+          value: "true"
+        - name: STREAM_COUNT
+          value: "1"
+        - name: TIMEOUT
+          value: "60"
+        ports: 
+        - containerPort: 8080 
+        livenessProbe: 
+          tcpSocket: 
+            port: 8080 
+          initialDelaySeconds: 5 
+        readinessProbe: 
+          httpGet: 
+            port: 8080 
+            path: "/__gtg" 
+          initialDelaySeconds: 15 
+          periodSeconds: 30 
+        resources: 
+{{ toYaml .Values.resources | indent 12 }}
+

--- a/helm/concept-ingester/templates/deployment.yaml
+++ b/helm/concept-ingester/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           value: "Concept"
         - name: SERVICES
           value: "http://content-rw-neo4j:8080,http://people-rw-neo4j:8080,http://organisations-rw-neo4j:8080,http://memberships-rw-neo4j:8080,http://brands-rw-neo4j:8080,http://roles-rw-neo4j:8080,http://financial-instruments-rw-neo4j:8080,http://industry-classifications-rw-neo4j:8080"
-        - name: ELASTICSEARCH_WRITER_ADDRESS
+        - name: ELASTICSEARCH_WRITER
           value: "http://concept-rw-elasticsearch:8080"
         - name: GRAPHITE_TCP_AUTHORITY
           valueFrom:

--- a/helm/concept-ingester/templates/service.yaml
+++ b/helm/concept-ingester/templates/service.yaml
@@ -5,7 +5,8 @@ apiVersion: v1
 metadata:
   name: {{.Values.service.name}} 
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ .Chart.Name | trunc 63 }}"
+    chartVersion: "{{ .Chart.Version | trunc 63 }}"
     app: {{.Values.service.name}}
     visualize: "true" 
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 

--- a/helm/concept-ingester/templates/service.yaml
+++ b/helm/concept-ingester/templates/service.yaml
@@ -1,0 +1,18 @@
+##this is an example service.yaml that should be customized in order to meet the configuration for app service
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{.Values.service.name}} 
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{.Values.service.name}}
+    visualize: "true" 
+    hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+spec:
+  ports: 
+    - port: 8080 
+#      name: # The name of this port within the service. Optional if only one port is defined on this service
+      targetPort: 8080 
+  selector: 
+    app: {{ .Values.service.name }} 

--- a/helm/concept-ingester/values.yaml
+++ b/helm/concept-ingester/values.yaml
@@ -1,0 +1,15 @@
+# Default values for concept-ingester.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+service:
+  name: "" # The name of the service, should be defined in the specific app-configs folder.
+  hasHealthcheck: "true"
+replicaCount: 2
+image:
+  repository: coco/concept-ingester
+  pullPolicy: IfNotPresent
+resources:
+  limits:
+    memory: 256Mi
+
+


### PR DESCRIPTION
- implemented a switch based on the consumer queue param:
  - if it's empty, we don't use vulcan routing
  - if it's set, we use vulcan routing
- helm integration